### PR TITLE
Allows access to galera finalizers in operator roles

### DIFF
--- a/example-manifests/galera-operator/20-role.yaml
+++ b/example-manifests/galera-operator/20-role.yaml
@@ -19,7 +19,9 @@ rules:
       - sql.databases
     resources:
       - galeras/status
+      - galeras/finalizers
       - galerabackups/status
+      - galerabackups/finalizers
     verbs:
       - "*"
   - apiGroups:


### PR DESCRIPTION
Creating a galera-cluster on openshift 4.3 fails with the following error in the operator:

```
E0518 14:31:49.052608       1 galera_controller.go:356] galera-operator/galera-cluster failed with : error syncing 'galera-operator/galera-cluster': controllerrevisions.apps "galera-cluster-96755dc59" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
```