### PR TITLE
Removes explicit user argument for galera container

### DIFF
--- a/pkg/galera/pod.go
+++ b/pkg/galera/pod.go
@@ -131,7 +131,7 @@ func bootstrapContainer(bootstrapImage, user, password, clusterName, name, addre
 }
 
 func galeraContainer(image, user, password , role string) corev1.Container {
-	argContainer := []string{fmt.Sprintf("--defaults-file=%s/my.cnf", apigalera.BootstrapVolumeMountPath), "--user=mysql"}
+	argContainer := []string{fmt.Sprintf("--defaults-file=%s/my.cnf", apigalera.BootstrapVolumeMountPath)}
 
 	mounts := []corev1.VolumeMount{bootstrapVolumeMount(), galeraVolumeMount(role)}
 


### PR DESCRIPTION
the user can still be specified through `my.cnf`, this allows deployment on Openshift, where the user cannot be predetermined, by not specifying a user in `my.cnf`